### PR TITLE
Extend doofinder feed with extra column

### DIFF
--- a/feed.php
+++ b/feed.php
@@ -70,6 +70,42 @@ function slugify($text)
     return $text;
 }
 
+/**
+ *  Merge multidemensionnal array by value on each row
+ *  https://stackoverflow.com/questions/7973915/php-merge-arrays-by-value
+ */
+function array_merge_by_id_product($array1 = array(), $array2 = array())
+{
+    $sub_key = 'id_product';
+    $result = array();
+    $result_row = array();
+
+    if (empty($array1)) {
+      return $array2;
+    }
+    if (empty($array2)) {
+      return $array1;
+    }
+
+    foreach ($array1 as $item1) {
+        $result_row = array();
+        //Merge data
+        foreach ($array2 as $key => $item2) {
+            if($item1[$sub_key] == $item2[$sub_key]) {
+              $result_row = array_merge($item1, $item2);
+              break;
+            }
+        }
+        //If no array merged
+        if (empty($result_row)) {
+            $result_row = $item1;
+        }
+        $result[] = $result_row;
+    }
+
+    return $result;
+}
+
 $context = Context::getContext();
 
 $shop = new Shop((int) $context->shop->id);
@@ -197,6 +233,34 @@ if ($cfg_product_features) {
 }
 
 
+/*
+ * Extend doofinder feed
+ *
+ * To add an new header, module can do an array_merge on $extra_header
+ * To add an new data to a product, module must create a multidemensionnal array as this :
+ * array(
+ *   index => array(
+ *    'id_product' => value,
+ *    'new_header_column_name' => 'value related to the new column'
+ *   ),
+ *   [...]
+ * )
+ * As each module can extend $extra_header and $extra_rows don't forget to merge them
+ */
+$extra_header = array();
+$extra_row = array();
+Hook::exec('actionDoofinderExtendFeed', array(
+    'extra_header'   => &$extra_header,
+    'extra_rows' => &$extra_rows,
+    'id_lang' => $lang->id,
+    'id_shop' => $shop->id,
+    'limit' => $limit,
+    'offset' => $offset,
+));
+
+if (!empty($extra_header)) {
+    $header = array_merge($header, $extra_header);
+}
 
 if (!$limit || ($offset !== false && (int)$offset === 0)) {
     echo implode(TXT_SEPARATOR, $header) . PHP_EOL;
@@ -204,7 +268,12 @@ if (!$limit || ($offset !== false && (int)$offset === 0)) {
 }
 
 // PRODUCTS
-foreach (dfTools::getAvailableProductsForLanguage($lang->id, $shop->id, $limit, $offset) as $row) {
+$rows = dfTools::getAvailableProductsForLanguage($lang->id, $shop->id, $limit, $offset);
+if (!empty($extra_rows)) {
+    $rows = array_merge_by_id_product($rows, $extra_rows);
+}
+
+foreach ($rows as $row) {
     if ((int)$row['id_product'] > 0) {
         // ID, TITLE, LINK
 
@@ -447,6 +516,11 @@ foreach (dfTools::getAvailableProductsForLanguage($lang->id, $shop->id, $limit, 
             foreach (dfTools::getFeaturesForProduct($row['id_product'], $lang->id, $feature_keys) as $key => $value) {
                 echo slugify($key) . "=" . dfTools::cleanString($value) . "/";
             }
+        }
+
+        foreach ($extra_header as $extra) {
+            echo TXT_SEPARATOR;
+            echo isset($row[$extra]) ? $row[$extra] : "";
         }
 
         echo PHP_EOL;


### PR DESCRIPTION
Solve #1

Allow external module to extend feed data. New data must set in $params['extra_header] and $params['extra_rows']
As sample add df_rating value.
```
    public function hookactionDoofinderExtendFeed($params)
    {
        //extra_row
        $df_rating_name = "df_rating";
        $extra_rows = array();
        //Merge new header column
        $params['extra_header'] = array_merge($params['extra_header'], array($df_rating_name));

        $query = new DbQuery();
        $query->select('id_product')
                ->from('product')
                ->where('active = 1')
                ->where('visibility IN ("search", "both")')
                ->orderBy('id_product')
                ->limit($params['limit'], $params['offset']);
        $rows = Db::getInstance()->executeS($query);

        foreach ($rows as $key => $row) {
            $rating = MyModule::getRating(
                array(
                  'id_product' => $row['id_product'],
                )
            );
            $extra_rows[] = array(
                'id_product' => $row['id_product'],
                $df_rating_name => $rating['average'] ? $rating['average'] : ""
            );
        }
    }
    $params['extra_rows'] = array_merge_by_id_product($params['extra_rows'], $extra_rows);
```
* Backported from https://github.com/doofinder/doofinder-prestashop/pull/45